### PR TITLE
set IPV6_V6ONLY on the coap socket

### DIFF
--- a/src/smcp/smcp.c
+++ b/src/smcp/smcp.c
@@ -163,6 +163,16 @@ smcp_init(
 		strerror(prev_errno)
 	);
 
+#ifdef IPV6_V6ONLY
+	{
+		int value = 0; /* explicitly allow ipv4 traffic too (required on bsd and some debian installations) */
+		if (setsockopt(self->fd, IPPROTO_IPV6, IPV6_V6ONLY, &value, sizeof(value)) < 0)
+		{
+			DEBUG_PRINTF(CSTR("Socket won't allow IPv4 connections"));
+		}
+	}
+#endif
+
 	// Keep attempting to bind until we find a port that works.
 	while(bind(self->fd, (struct sockaddr*)&saddr, sizeof(saddr)) != 0) {
 		// We should only continue trying if errno == EADDRINUSE.


### PR DESCRIPTION
some operating systems (bsd, some debian based systems[1]), sockets have
to explicitly request ipv6-wrapped ipv4 packages (eg. from
::ffff:192.168.0.1). this patch makes smcp request those if the
setsockopt flag to do so is defined, as this is the only way for the
code to deal with ipv4 packages.

see [1] for a discussion on the default values of this option.

[1] http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=560238
