### PR TITLE
fix compilation error

### DIFF
--- a/src/smcpctl/main.c
+++ b/src/smcpctl/main.c
@@ -554,8 +554,8 @@ initialize_readline() {
 	rl_readline_name = "smcp";
 	rl_completer_word_break_characters = " \t\n\"\\'`@$><|&{("; // Removed '=' ';'
 	/* Tell the completer that we want a crack first. */
-	rl_attempted_completion_function = (CPPFunction *)smcp_attempted_completion;
-	rl_completion_entry_function = (Function*)&smcp_directory_generator;
+	rl_attempted_completion_function = smcp_attempted_completion;
+	rl_completion_entry_function = smcp_directory_generator;
 
 	using_history();
 	read_history(getenv("SMCP_HISTORY_FILE"));


### PR DESCRIPTION
Using GCC 4.8.2, smcp isn't compiling out of the box due to undefined casts. This fixes the problem.
