### PR TITLE
Make the library thread-safe. DO NOT MERGE.

### DIFF
--- a/src/smcp/smcp-auth.c
+++ b/src/smcp/smcp-auth.c
@@ -191,23 +191,23 @@ smcp_auth_get_cred(
 }
 
 smcp_status_t
-smcp_auth_inbound_init() {
+smcp_auth_inbound_init(smcp_t self) {
 	smcp_status_t ret = SMCP_STATUS_OK;
 
-	if (COAP_CODE_IS_REQUEST(smcp_inbound_get_code())) {
+	if (COAP_CODE_IS_REQUEST(smcp_inbound_get_code(self))) {
 		// REQUEST!
 		coap_option_key_t key;
 		const uint8_t* authvalue;
 		coap_size_t authvalue_len;
 
 		// For testing purposes only!
-		if(smcp_inbound_get_code() >1 && smcp_inbound_get_code()<COAP_RESULT_100) {
+		if(smcp_inbound_get_code(self) >1 && smcp_inbound_get_code(self)<COAP_RESULT_100) {
 			ret = SMCP_STATUS_UNAUTHORIZED;
 		}
 
-		smcp_inbound_reset_next_option();
+		smcp_inbound_reset_next_option(self);
 
-		while((key = smcp_inbound_next_option(&authvalue,&authvalue_len))!=COAP_OPTION_INVALID) {
+		while((key = smcp_inbound_next_option(self,&authvalue,&authvalue_len))!=COAP_OPTION_INVALID) {
 			if(key==COAP_OPTION_PROXY_URI) {
 				// For testing purposes only!
 				ret = SMCP_STATUS_OK;
@@ -219,7 +219,7 @@ smcp_auth_inbound_init() {
 			}
 		}
 
-		if(smcp_inbound_origin_is_local()) {
+		if(smcp_inbound_origin_is_local(self)) {
 			ret = SMCP_STATUS_OK;
 		}
 
@@ -227,9 +227,9 @@ smcp_auth_inbound_init() {
 		ret = SMCP_STATUS_OK;
 
 		if(ret == SMCP_STATUS_UNAUTHORIZED) {
-			smcp_outbound_begin_response(COAP_RESULT_401_UNAUTHORIZED);
-			smcp_outbound_add_option(COAP_OPTION_AUTHENTICATE,NULL,0);
-			smcp_outbound_send();
+			smcp_outbound_begin_response(self, COAP_RESULT_401_UNAUTHORIZED);
+			smcp_outbound_add_option(self, COAP_OPTION_AUTHENTICATE,NULL,0);
+			smcp_outbound_send(self);
 		}
 	} else {
 		// RESPONSE!
@@ -239,7 +239,7 @@ smcp_auth_inbound_init() {
 }
 
 smcp_status_t
-smcp_auth_outbound_finalize() {
+smcp_auth_outbound_finalize(smcp_t self) {
 	// This method is for updating the response values in the authenticate
 	// header, if it needs to be updated for digest-auth-int.
 
@@ -249,7 +249,7 @@ smcp_auth_outbound_finalize() {
 }
 
 smcp_status_t
-smcp_auth_outbound_set_credentials(const char* username, const char* password) {
+smcp_auth_outbound_set_credentials(smcp_t self, const char* username, const char* password) {
 	smcp_status_t ret = SMCP_STATUS_OK;
 	smcp_auth_user_t auth_user;
 
@@ -262,7 +262,7 @@ smcp_auth_outbound_set_credentials(const char* username, const char* password) {
 	if(!auth_user) {
 
 		// Just do something stupid for now.
-		ret = smcp_outbound_add_option(COAP_OPTION_AUTHENTICATE, NULL, 0);
+		ret = smcp_outbound_add_option(self, COAP_OPTION_AUTHENTICATE, NULL, 0);
 
 		require(password, bail);
 
@@ -276,33 +276,33 @@ bail:
 }
 
 smcp_status_t
-smcp_auth_outbound_init(void)
+smcp_auth_outbound_init(smcp_t self)
 {
 	return SMCP_STATUS_OK;
 }
 
 smcp_status_t
-smcp_auth_outbound_use_dtls()
+smcp_auth_outbound_use_dtls(smcp_t self)
 {
 	return SMCP_STATUS_NOT_IMPLEMENTED;
 }
 
 bool
-smcp_auth_outbound_is_using_dtls(void)
+smcp_auth_outbound_is_using_dtls(smcp_t self)
 {
 	// TODO: Writeme!
 	return false;
 }
 
 const char*
-smcp_auth_inbound_get_username()
+smcp_auth_inbound_get_username(smcp_t self)
 {
 	// TODO: Writeme!
 	return NULL;
 }
 
 smcp_status_t
-smcp_inbound_set_ext_auth(const char* cn, const char* mechanism)
+smcp_inbound_set_ext_auth(smcp_t self, const char* cn, const char* mechanism)
 {
 	// TODO: Writeme!
 	return SMCP_STATUS_OK;

--- a/src/smcp/smcp-auth.h
+++ b/src/smcp/smcp-auth.h
@@ -76,14 +76,15 @@ struct smcp_auth_transaction_s {
 //////////////////////////////////////////////////
 // Inbound Methods
 
-extern smcp_status_t smcp_auth_inbound_init(void);
+extern smcp_status_t smcp_auth_inbound_init(smcp_t self);
 
-extern const char* smcp_auth_inbound_get_username(void);
+extern const char* smcp_auth_inbound_get_username(smcp_t self);
 
 //! Describes external authentication (e.g. DTLS)
 /*!	Must be called between smcp_inbound_start_packet() and smcp_inbound_finish_packet().
 **	@sa smcp-auth */
 extern smcp_status_t smcp_inbound_set_ext_auth(
+	smcp_t smcp,
 	const char* cn,			//!< Common Name
 	const char* mechanism	//!< Authentication Mechanism
 );
@@ -91,15 +92,15 @@ extern smcp_status_t smcp_inbound_set_ext_auth(
 //////////////////////////////////////////////////
 // Outbound Methods
 
-extern smcp_status_t smcp_auth_outbound_init(void);
+extern smcp_status_t smcp_auth_outbound_init(smcp_t self);
 
-extern smcp_status_t smcp_auth_outbound_finalize(void);
+extern smcp_status_t smcp_auth_outbound_finalize(smcp_t self);
 
-extern smcp_status_t smcp_auth_outbound_use_dtls();
+extern smcp_status_t smcp_auth_outbound_use_dtls(smcp_t self);
 
-extern bool smcp_auth_outbound_is_using_dtls(void);
+extern bool smcp_auth_outbound_is_using_dtls(smcp_t self);
 
-extern smcp_status_t smcp_auth_outbound_set_credentials(const char* username, const char* password);
+extern smcp_status_t smcp_auth_outbound_set_credentials(smcp_t self, const char* username, const char* password);
 
 //extern smcp_status_t smcp_auth_get_cred(
 //	const char* realm,

--- a/src/smcp/smcp-curl_proxy.h
+++ b/src/smcp/smcp-curl_proxy.h
@@ -70,7 +70,7 @@ extern smcp_status_t smcp_curl_proxy_node_update_fdset(
 
 extern smcp_status_t smcp_curl_proxy_node_process(smcp_curl_proxy_node_t node);
 
-extern smcp_status_t smcp_curl_proxy_request_handler(smcp_curl_proxy_node_t node);
+extern smcp_status_t smcp_curl_proxy_request_handler(smcp_t self, smcp_curl_proxy_node_t node);
 
 /*!	@} */
 /*!	@} */

--- a/src/smcp/smcp-internal.h
+++ b/src/smcp/smcp-internal.h
@@ -57,14 +57,6 @@
 
 __BEGIN_DECLS
 
-#if SMCP_EMBEDDED
-// Embedded platforms only support one instance.
-#define smcp_set_current_instance(x)
-#else
-extern void smcp_set_current_instance(smcp_t x);
-#endif
-
-
 #ifndef SMCP_HOOK_TIMER_NEEDS_REFRESH
 #define SMCP_HOOK_TIMER_NEEDS_REFRESH(x)	do { } while (0)
 #endif
@@ -202,15 +194,11 @@ struct smcp_s {
 	const char* proxy_url;
 };
 
-
 extern smcp_status_t smcp_handle_request();
-
 extern smcp_status_t smcp_handle_response();
-
-extern smcp_status_t smcp_outbound_set_var_content_int(int v);
-extern smcp_status_t smcp_outbound_set_var_content_unsigned_int(unsigned int v);
-extern smcp_status_t smcp_outbound_set_var_content_unsigned_long_int(unsigned long int v);
-
+extern smcp_status_t smcp_outbound_set_var_content_int(smcp_t self, int v);
+extern smcp_status_t smcp_outbound_set_var_content_unsigned_int(smcp_t self, unsigned int v);
+extern smcp_status_t smcp_outbound_set_var_content_unsigned_long_int(smcp_t self, unsigned long int v);
 
 __END_DECLS
 

--- a/src/smcp/smcp-node-router.c
+++ b/src/smcp/smcp-node-router.c
@@ -62,30 +62,27 @@ static struct smcp_node_s smcp_node_pool[SMCP_CONF_MAX_ALLOCED_NODES];
 #pragma mark -
 
 smcp_status_t
-smcp_default_request_handler(
-   smcp_node_t node
-) {
-   if(smcp_inbound_get_code() == COAP_METHOD_GET) {
-	   return smcp_handle_list(node);
+smcp_default_request_handler(smcp_t self, smcp_node_t node) {
+   if(smcp_inbound_get_code(self) == COAP_METHOD_GET) {
+	   return smcp_handle_list(self, node);
    }
    return SMCP_STATUS_NOT_ALLOWED;
 }
 
 smcp_status_t
-smcp_node_router_handler(void* context) {
+smcp_node_router_handler(smcp_t self, void* context) {
 	smcp_request_handler_func handler = NULL;
-	smcp_node_route(context, &handler, &context);
+	smcp_node_route(self, context, &handler, &context);
 	if(!handler)
 		return SMCP_STATUS_NOT_IMPLEMENTED;
-	return (*handler)(context);
+	return (*handler)(self, context);
 }
 
 smcp_status_t
-smcp_node_route(smcp_node_t node, smcp_request_handler_func* func, void** context) {
+smcp_node_route(smcp_t self, smcp_node_t node, smcp_request_handler_func* func, void** context) {
 	smcp_status_t ret = 0;
-	smcp_t const self = smcp_get_current_instance();
 
-	smcp_inbound_reset_next_option();
+	smcp_inbound_reset_next_option(self);
 
 	{
 		// TODO: Rewrite this to be more efficient.
@@ -94,7 +91,7 @@ smcp_node_route(smcp_node_t node, smcp_request_handler_func* func, void** contex
 		coap_option_key_t key;
 		const uint8_t* value;
 		coap_size_t value_len;
-		while((key=smcp_inbound_next_option(&value, &value_len))!=COAP_OPTION_INVALID) {
+		while((key=smcp_inbound_next_option(self, &value, &value_len))!=COAP_OPTION_INVALID) {
 			if(key>COAP_OPTION_URI_PATH) {
 				self->inbound.this_option = prev_option_ptr;
 				self->inbound.last_option_key = prev_key;

--- a/src/smcp/smcp-node-router.h
+++ b/src/smcp/smcp-node-router.h
@@ -78,13 +78,13 @@ struct smcp_node_s {
 extern bt_compare_result_t smcp_node_compare(smcp_node_t lhs, smcp_node_t rhs);
 
 #if SMCP_EMBEDDED
-#define smcp_node_get_root(x)		((smcp_node_t)smcp_get_current_instance())
+// TODO: #define smcp_node_get_root(x) returning instance
 #else
 extern smcp_node_t smcp_node_get_root(smcp_node_t node);
 #endif
 
-extern smcp_status_t smcp_node_router_handler(void* context);
-extern smcp_status_t smcp_node_route(smcp_node_t node, smcp_request_handler_func* func, void** context);
+extern smcp_status_t smcp_node_router_handler(smcp_t self, void* context);
+extern smcp_status_t smcp_node_route(smcp_t self, smcp_node_t node, smcp_request_handler_func* func, void** context);
 
 extern smcp_node_t smcp_node_alloc();
 
@@ -127,10 +127,11 @@ extern int smcp_node_find_next_with_path(
 );
 
 extern smcp_status_t smcp_default_request_handler(
+    smcp_t self,
 	smcp_node_t		node
 );
 
-extern smcp_status_t smcp_handle_list(smcp_node_t node);
+extern smcp_status_t smcp_handle_list(smcp_t self, smcp_node_t node);
 
 /*!	@} */
 /*!	@} */

--- a/src/smcp/smcp-observable.h
+++ b/src/smcp/smcp-observable.h
@@ -80,6 +80,7 @@ typedef struct smcp_observable_s *smcp_observable_t;
 **	to smcp_observable_trigger() to trigger updates.
 */
 extern smcp_status_t smcp_observable_update(
+	smcp_t self,
 	smcp_observable_t context, //!< [IN] Pointer to observable context
 	uint8_t key		//!< [IN] Key for this resource (must be same as used in trigger)
 );

--- a/src/smcp/smcp-outbound.c
+++ b/src/smcp/smcp-outbound.c
@@ -67,36 +67,23 @@ extern void *uip_sappdata;
 #pragma mark Constrained sending API
 
 void
-smcp_outbound_drop() {
-	smcp_t self = smcp_get_current_instance();
-
+smcp_outbound_drop(smcp_t self) {
 	self->is_responding = false;
 	self->did_respond = true;
 }
 
 void
-smcp_outbound_reset()
+smcp_outbound_reset(smcp_t self)
 {
-	memset(&smcp_get_current_instance()->outbound, 0, sizeof(smcp_get_current_instance()->outbound));
-	smcp_get_current_instance()->is_responding = false;
-	smcp_get_current_instance()->did_respond = false;
+	memset(&self->outbound, 0, sizeof(self->outbound));
+	self->is_responding = false;
+	self->did_respond = false;
 }
 
 smcp_status_t
 smcp_outbound_begin(
 	smcp_t self, coap_code_t code, coap_transaction_type_t tt
 ) {
-	SMCP_EMBEDDED_SELF_HOOK;
-
-#if !SMCP_EMBEDDED
-	if(!self)
-		self = smcp_get_current_instance();
-#endif
-
-	check(!smcp_get_current_instance() || smcp_get_current_instance()==self);
-
-	smcp_set_current_instance(self);
-
 #if SMCP_USE_CASCADE_COUNT
 	if(self->cascade_count == 1)
 		return SMCP_STATUS_CASCADE_LOOP;
@@ -158,14 +145,13 @@ smcp_outbound_begin(
 	self->force_current_outbound_code = false;
 	self->is_responding = false;
 
-	smcp_auth_outbound_init();
+	smcp_auth_outbound_init(self);
 
 	return SMCP_STATUS_OK;
 }
 
-smcp_status_t smcp_outbound_begin_response(coap_code_t code) {
+smcp_status_t smcp_outbound_begin_response(smcp_t self, coap_code_t code) {
 	smcp_status_t ret;
-	smcp_t const self = smcp_get_current_instance();
 
 	ret = SMCP_STATUS_OK;
 
@@ -179,7 +165,7 @@ smcp_status_t smcp_outbound_begin_response(coap_code_t code) {
 	require_quiet(!self->is_responding, bail);
 
 	if(self->is_processing_message)
-		self->outbound.next_tid = smcp_inbound_get_msg_id();
+		self->outbound.next_tid = smcp_inbound_get_msg_id(self);
 	ret = smcp_outbound_begin(
 		self,
 		code,
@@ -189,9 +175,9 @@ smcp_status_t smcp_outbound_begin_response(coap_code_t code) {
 	self->is_responding = true;
 
 	if(self->is_processing_message) {
-		require_noerr(ret=smcp_outbound_set_msg_id(smcp_inbound_get_msg_id()),bail);
+		require_noerr(ret=smcp_outbound_set_msg_id(self, smcp_inbound_get_msg_id(self)),bail);
 
-		ret = smcp_outbound_set_destaddr(&self->inbound.saddr);
+		ret = smcp_outbound_set_destaddr(self, &self->inbound.saddr);
 		require_noerr(ret, bail);
 	}
 bail:
@@ -202,24 +188,21 @@ bail:
 }
 
 smcp_status_t
-smcp_outbound_set_msg_id(coap_msg_id_t tid) {
-	assert(smcp_get_current_instance()->outbound.packet);
-	smcp_get_current_instance()->outbound.packet->msg_id = tid;
+smcp_outbound_set_msg_id(smcp_t self, coap_msg_id_t tid) {
+	self->outbound.packet->msg_id = tid;
 	return SMCP_STATUS_OK;
 }
 
 smcp_status_t
-smcp_outbound_set_code(coap_code_t code) {
-	smcp_t const self = smcp_get_current_instance();
+smcp_outbound_set_code(smcp_t self, coap_code_t code) {
 	if(!self->force_current_outbound_code)
 		self->outbound.packet->code = code;
 	return SMCP_STATUS_OK;
 }
 
 smcp_status_t
-smcp_outbound_set_token(const uint8_t *token,uint8_t token_length) {
+smcp_outbound_set_token(smcp_t self, const uint8_t *token,uint8_t token_length) {
 	smcp_status_t ret;
-	smcp_t const self = smcp_get_current_instance();
 
 	ret = SMCP_STATUS_OK;
 
@@ -241,14 +224,12 @@ bail:
 
 static smcp_status_t
 smcp_outbound_add_option_(
-	coap_option_key_t key, const char* value, coap_size_t len
+	smcp_t self, coap_option_key_t key, const char* value, coap_size_t len
 ) {
-	smcp_t const self = smcp_get_current_instance();
-
 	if(len == SMCP_CSTR_LEN)
 		len = strlen(value);
 
-	if(	smcp_outbound_get_space_remaining() < len + 8 ) {
+	if(	smcp_outbound_get_space_remaining(self) < len + 8 ) {
 		// We ran out of room!
 		return SMCP_STATUS_MESSAGE_TOO_BIG;
 	}
@@ -287,10 +268,9 @@ smcp_outbound_add_option_(
 
 static smcp_status_t
 smcp_outbound_add_options_up_to_key_(
-	coap_option_key_t key
+	smcp_t self, coap_option_key_t key
 ) {
 	smcp_status_t ret;
-	smcp_t const self = smcp_get_current_instance();
 
 	ret = SMCP_STATUS_OK;
 
@@ -303,6 +283,7 @@ smcp_outbound_add_options_up_to_key_(
 		uint32_t block2 = htonl(self->current_transaction->next_block2);
 		uint8_t size = 3; // SEC-TODO: calculate this properly
 		ret = smcp_outbound_add_option_(
+			self,
 			COAP_OPTION_BLOCK2,
 			(char*)&block2+sizeof(block2)-size,
 			size
@@ -318,6 +299,7 @@ smcp_outbound_add_options_up_to_key_(
 		if(self->outbound.packet->code && self->outbound.packet->code<COAP_RESULT_100) {
 			// For sending a request.
 			ret = smcp_outbound_add_option_(
+				self,
 				COAP_OPTION_OBSERVE,
 				(void*)NULL,
 				0
@@ -333,6 +315,7 @@ smcp_outbound_add_options_up_to_key_(
 	) {
 		uint8_t cc = self->cascade_count-1;
 		ret = smcp_outbound_add_option_(
+			self,
 			COAP_OPTION_CASCADE_COUNT,
 			(char*)&cc,
 			1
@@ -345,23 +328,23 @@ smcp_outbound_add_options_up_to_key_(
 
 smcp_status_t
 smcp_outbound_add_option(
-	coap_option_key_t key, const char* value, coap_size_t len
+	smcp_t self, coap_option_key_t key, const char* value, coap_size_t len
 ) {
 	smcp_status_t ret;
 
-	ret = smcp_outbound_add_options_up_to_key_(key);
+	ret = smcp_outbound_add_options_up_to_key_(self, key);
 	require_noerr(ret, bail);
 
 #if SMCP_CONF_TRANS_ENABLE_BLOCK2
 	if(key==COAP_OPTION_BLOCK2
-		&& smcp_get_current_instance()->current_transaction
-		&& smcp_get_current_instance()->current_transaction->next_block2
+		&& self->current_transaction
+		&& self->current_transaction->next_block2
 	) {
 		goto bail;
 	}
 #endif
 
-	ret = smcp_outbound_add_option_(key,value,len);
+	ret = smcp_outbound_add_option_(self, key, value, len);
 	require_noerr(ret, bail);
 
 bail:
@@ -369,21 +352,20 @@ bail:
 }
 
 smcp_status_t
-smcp_outbound_add_option_uint(coap_option_key_t key,uint32_t value) {
+smcp_outbound_add_option_uint(smcp_t self, coap_option_key_t key,uint32_t value) {
 	if(value>>24)
-		return value = htonl(value),smcp_outbound_add_option(key, ((char*)&value)+0, 4);
+		return value = htonl(value),smcp_outbound_add_option(self, key, ((char*)&value)+0, 4);
 	else if(value>>16)
-		return value = htonl(value),smcp_outbound_add_option(key, ((char*)&value)+1, 3);
+		return value = htonl(value),smcp_outbound_add_option(self, key, ((char*)&value)+1, 3);
 	else if(value>>8)
-		return value = htonl(value),smcp_outbound_add_option(key, ((char*)&value)+2, 2);
+		return value = htonl(value),smcp_outbound_add_option(self, key, ((char*)&value)+2, 2);
 	else if(value)
-		return value = htonl(value),smcp_outbound_add_option(key, ((char*)&value)+3, 1);
-	return smcp_outbound_add_option(key, NULL, 0);
+		return value = htonl(value),smcp_outbound_add_option(self, key, ((char*)&value)+3, 1);
+	return smcp_outbound_add_option(self, key, NULL, 0);
 }
 
 smcp_status_t
-smcp_outbound_set_destaddr(const smcp_sockaddr_t* sockaddr) {
-	smcp_t const self = smcp_get_current_instance();
+smcp_outbound_set_destaddr(smcp_t self, const smcp_sockaddr_t* sockaddr) {
 	memcpy(
 		&self->outbound.saddr,
 		sockaddr,
@@ -402,7 +384,7 @@ smcp_outbound_set_destaddr(const smcp_sockaddr_t* sockaddr) {
 }
 
 smcp_status_t
-smcp_outbound_set_destaddr_from_host_and_port(const char* addr_str,uint16_t toport) {
+smcp_outbound_set_destaddr_from_host_and_port(smcp_t self, const char* addr_str,uint16_t toport) {
 	smcp_status_t ret;
 	SMCP_NON_RECURSIVE smcp_sockaddr_t saddr;
 
@@ -412,16 +394,15 @@ smcp_outbound_set_destaddr_from_host_and_port(const char* addr_str,uint16_t topo
 	if(strcasecmp(addr_str, COAP_MULTICAST_STR_ALLDEVICES)==0)
 		addr_str = SMCP_COAP_MULTICAST_ALLDEVICES_ADDR;
 
-	ret = smcp_internal_lookup_hostname(addr_str, &saddr);
+	ret = smcp_internal_lookup_hostname(self, addr_str, &saddr);
 	require_noerr(ret,bail);
 
 	saddr.smcp_port = htons(toport);
 
-	ret = smcp_outbound_set_destaddr(&saddr);
+	ret = smcp_outbound_set_destaddr(self, &saddr);
 	require_noerr(ret, bail);
 
 	if(SMCP_IS_ADDR_MULTICAST(&saddr.smcp_addr)) {
-		smcp_t const self = smcp_get_current_instance();
 		check(self->outbound.packet->tt != COAP_TRANS_TYPE_CONFIRMABLE);
 		if(self->outbound.packet->tt == COAP_TRANS_TYPE_CONFIRMABLE) {
 			self->outbound.packet->tt = COAP_TRANS_TYPE_NONCONFIRMABLE;
@@ -434,10 +415,9 @@ bail:
 
 smcp_status_t
 smcp_outbound_set_uri(
-	const char* uri, char flags
+	smcp_t self, const char* uri, char flags
 ) {
 	smcp_status_t ret;
-	smcp_t const self = smcp_get_current_instance();
 	SMCP_NON_RECURSIVE struct url_components_s components;
 	SMCP_NON_RECURSIVE uint16_t toport;
 	SMCP_NON_RECURSIVE char* uri_copy;
@@ -475,7 +455,7 @@ smcp_outbound_set_uri(
 			// Talking to ourself.
 			components.protocol = "coap";
 			components.host = "::1";
-			toport = smcp_get_port(smcp_get_current_instance());
+			toport = smcp_get_port(self);
 			flags |= SMCP_MSG_SKIP_AUTHORITY;
 		} else if(components.port) {
 			toport = atoi(components.port);
@@ -496,7 +476,7 @@ smcp_outbound_set_uri(
 			// There is a lot more that is needed for this to work...
 			toport = COAP_DEFAULT_TLSPORT;
 
-			require_noerr(ret = smcp_auth_outbound_use_dtls(), bail);
+			require_noerr(ret = smcp_auth_outbound_use_dtls(self), bail);
 		} else
 #endif
 		if(!strequal_const(components.protocol, "coap")) {
@@ -508,20 +488,20 @@ smcp_outbound_set_uri(
 			);
 			require_action(uri!=self->proxy_url,bail,ret = SMCP_STATUS_INVALID_ARGUMENT);
 
-			ret = smcp_outbound_add_option(COAP_OPTION_PROXY_URI, uri, strlen(uri));
+			ret = smcp_outbound_add_option(self, COAP_OPTION_PROXY_URI, uri, strlen(uri));
 			require_noerr(ret, bail);
-			ret = smcp_outbound_set_uri(self->proxy_url,flags);
+			ret = smcp_outbound_set_uri(self, self->proxy_url,flags);
 			goto bail;
 		}
 	}
 
 	if(!(flags&SMCP_MSG_SKIP_AUTHORITY)) {
 		if(components.host && !string_contains_colons(components.host)) {
-			ret = smcp_outbound_add_option(COAP_OPTION_URI_HOST, components.host, strlen(components.host));
+			ret = smcp_outbound_add_option(self, COAP_OPTION_URI_HOST, components.host, strlen(components.host));
 			require_noerr(ret, bail);
 		}
 		if(components.port) {
-			ret = smcp_outbound_add_option_uint(COAP_OPTION_URI_PORT, toport);
+			ret = smcp_outbound_add_option_uint(self, COAP_OPTION_URI_PORT, toport);
 			require_noerr(ret, bail);
 		}
 	}
@@ -529,12 +509,12 @@ smcp_outbound_set_uri(
 	if(	!(flags&SMCP_MSG_SKIP_DESTADDR)
 		&& components.host && components.host[0]!=0
 	) {
-		ret = smcp_outbound_set_destaddr_from_host_and_port(components.host,toport);
+		ret = smcp_outbound_set_destaddr_from_host_and_port(self, components.host,toport);
 		require_noerr(ret, bail);
 	}
 
 	if(components.username) {
-		ret = smcp_auth_outbound_set_credentials(components.username, components.password);
+		ret = smcp_auth_outbound_set_credentials(self, components.username, components.password);
 		require_noerr(ret, bail);
 	}
 
@@ -547,11 +527,11 @@ smcp_outbound_set_uri(
 			components.path++;
 
 		while(url_path_next_component(&components.path,&component)) {
-			ret = smcp_outbound_add_option(COAP_OPTION_URI_PATH, component, SMCP_CSTR_LEN);
+			ret = smcp_outbound_add_option(self, COAP_OPTION_URI_PATH, component, SMCP_CSTR_LEN);
 			require_noerr(ret,bail);
 		}
 		if(has_trailing_slash) {
-			ret = smcp_outbound_add_option(COAP_OPTION_URI_PATH, NULL, 0);
+			ret = smcp_outbound_add_option(self, COAP_OPTION_URI_PATH, NULL, 0);
 			require_noerr(ret,bail);
 		}
 	}
@@ -562,7 +542,7 @@ smcp_outbound_set_uri(
 		while(url_form_next_value(&components.query,&key,NULL)) {
 			coap_size_t len = strlen(key);
 			if(len)
-				ret = smcp_outbound_add_option(COAP_OPTION_URI_QUERY, key, len);
+				ret = smcp_outbound_add_option(self, COAP_OPTION_URI_QUERY, key, len);
 			require_noerr(ret,bail);
 		}
 	}
@@ -579,9 +559,8 @@ bail:
 }
 
 coap_size_t
-smcp_outbound_get_space_remaining(void)
+smcp_outbound_get_space_remaining(smcp_t self)
 {
-	smcp_t const self = smcp_get_current_instance();
 	coap_size_t len = (self->outbound.content_ptr-(char*)self->outbound.packet)
 		+ self->outbound.content_len;
 	if (self->outbound.max_packet_len > len)
@@ -590,10 +569,9 @@ smcp_outbound_get_space_remaining(void)
 }
 
 smcp_status_t
-smcp_outbound_append_content(const char* value,coap_size_t len) {
+smcp_outbound_append_content(smcp_t self, const char* value,coap_size_t len) {
 	smcp_status_t ret = SMCP_STATUS_FAILURE;
-	smcp_t const self = smcp_get_current_instance();
-	coap_size_t max_len = smcp_outbound_get_space_remaining();
+	coap_size_t max_len = smcp_outbound_get_space_remaining(self);
 	char* dest;
 
 	if(len == SMCP_CSTR_LEN)
@@ -601,7 +579,7 @@ smcp_outbound_append_content(const char* value,coap_size_t len) {
 
 	require_action(max_len>len, bail, ret = SMCP_STATUS_MESSAGE_TOO_BIG);
 
-	dest = smcp_outbound_get_content_ptr(&max_len);
+	dest = smcp_outbound_get_content_ptr(self, &max_len);
 	require(dest,bail);
 
 	dest += self->outbound.content_len;
@@ -617,22 +595,20 @@ bail:
 }
 
 char*
-smcp_outbound_get_content_ptr(coap_size_t* max_len) {
-	smcp_t const self = smcp_get_current_instance();
-
+smcp_outbound_get_content_ptr(smcp_t self, coap_size_t* max_len) {
 	// Finish up any remaining automatically-added headers.
 	if(self->outbound.packet->code)
-		smcp_outbound_add_options_up_to_key_(COAP_OPTION_INVALID);
+		smcp_outbound_add_options_up_to_key_(self, COAP_OPTION_INVALID);
 
 	if(max_len)
-		*max_len = smcp_outbound_get_space_remaining()+self->outbound.content_len;
+		*max_len = smcp_outbound_get_space_remaining(self) + self->outbound.content_len;
 
 	return self->outbound.content_ptr;
 }
 
 smcp_status_t
-smcp_outbound_set_content_len(coap_size_t len) {
-	smcp_get_current_instance()->outbound.content_len = len;
+smcp_outbound_set_content_len(smcp_t self, coap_size_t len) {
+	self->outbound.content_len = len;
 	return SMCP_STATUS_OK;
 }
 
@@ -641,15 +617,15 @@ smcp_outbound_set_content_len(coap_size_t len) {
 
 #if !SMCP_AVOID_PRINTF
 smcp_status_t
-smcp_outbound_set_content_formatted(const char* fmt, ...) {
+smcp_outbound_set_content_formatted(smcp_t self, const char* fmt, ...) {
 	smcp_status_t ret = SMCP_STATUS_FAILURE;
 	va_list args;
-	char* content = smcp_outbound_get_content_ptr(NULL);
-	int len = smcp_outbound_get_space_remaining();
+	char* content = smcp_outbound_get_content_ptr(self, NULL);
+	int len = smcp_outbound_get_space_remaining(self);
 
 	require(content!=NULL, bail);
 
-	content += smcp_get_current_instance()->outbound.content_len;
+	content += self->outbound.content_len;
 
 	va_start(args,fmt);
 
@@ -657,8 +633,8 @@ smcp_outbound_set_content_formatted(const char* fmt, ...) {
 
 	require(len!=0,bail);
 
-	len += smcp_get_current_instance()->outbound.content_len;
-	ret = smcp_outbound_set_content_len(len);
+	len += self->outbound.content_len;
+	ret = smcp_outbound_set_content_len(self, len);
 
 bail:
 	va_end(args);
@@ -667,72 +643,71 @@ bail:
 #endif
 
 smcp_status_t
-smcp_outbound_set_var_content_int(int v) {
+smcp_outbound_set_var_content_int(smcp_t self, int v) {
 #if SMCP_AVOID_PRINTF
 	char nstr[12];
-	smcp_outbound_add_option_uint(COAP_OPTION_CONTENT_TYPE, SMCP_CONTENT_TYPE_APPLICATION_FORM_URLENCODED);
-	smcp_outbound_append_content("v=", SMCP_CSTR_LEN);
-	return smcp_outbound_append_content(int32_to_dec_cstr(nstr,v), SMCP_CSTR_LEN);
+	smcp_outbound_add_option_uint(self, COAP_OPTION_CONTENT_TYPE, SMCP_CONTENT_TYPE_APPLICATION_FORM_URLENCODED);
+	smcp_outbound_append_content(self, "v=", SMCP_CSTR_LEN);
+	return smcp_outbound_append_content(self, int32_to_dec_cstr(nstr,v), SMCP_CSTR_LEN);
 #else
-	smcp_outbound_add_option_uint(COAP_OPTION_CONTENT_TYPE, SMCP_CONTENT_TYPE_APPLICATION_FORM_URLENCODED);
-	return smcp_outbound_set_content_formatted_const("v=%d",v);
+	smcp_outbound_add_option_uint(self, COAP_OPTION_CONTENT_TYPE, SMCP_CONTENT_TYPE_APPLICATION_FORM_URLENCODED);
+	return smcp_outbound_set_content_formatted_const(self, "v=%d",v);
 #endif
 }
 
 smcp_status_t
-smcp_outbound_set_var_content_unsigned_int(unsigned int v) {
+smcp_outbound_set_var_content_unsigned_int(smcp_t self, unsigned int v) {
 #if SMCP_AVOID_PRINTF
 	char nstr[11];
-	smcp_outbound_add_option_uint(COAP_OPTION_CONTENT_TYPE, SMCP_CONTENT_TYPE_APPLICATION_FORM_URLENCODED);
-	smcp_outbound_append_content("v=", SMCP_CSTR_LEN);
-	return smcp_outbound_append_content(uint32_to_dec_cstr(nstr,v), SMCP_CSTR_LEN);
+	smcp_outbound_add_option_uint(self, COAP_OPTION_CONTENT_TYPE, SMCP_CONTENT_TYPE_APPLICATION_FORM_URLENCODED);
+	smcp_outbound_append_content(self, "v=", SMCP_CSTR_LEN);
+	return smcp_outbound_append_content(self, uint32_to_dec_cstr(nstr,v), SMCP_CSTR_LEN);
 #else
-	return smcp_outbound_set_content_formatted_const("v=%u",v);
+	return smcp_outbound_set_content_formatted_const(self, "v=%u",v);
 #endif
 }
 
 smcp_status_t
-smcp_outbound_set_var_content_unsigned_long_int(unsigned long int v) {
+smcp_outbound_set_var_content_unsigned_long_int(smcp_t self, unsigned long int v) {
 #if SMCP_AVOID_PRINTF
 	char nstr[11];
-	smcp_outbound_add_option_uint(COAP_OPTION_CONTENT_TYPE, SMCP_CONTENT_TYPE_APPLICATION_FORM_URLENCODED);
-	smcp_outbound_append_content("v=", SMCP_CSTR_LEN);
-	return smcp_outbound_append_content(uint32_to_dec_cstr(nstr,v), SMCP_CSTR_LEN);
+	smcp_outbound_add_option_uint(self, COAP_OPTION_CONTENT_TYPE, SMCP_CONTENT_TYPE_APPLICATION_FORM_URLENCODED);
+	smcp_outbound_append_content(self, "v=", SMCP_CSTR_LEN);
+	return smcp_outbound_append_content(self, uint32_to_dec_cstr(nstr,v), SMCP_CSTR_LEN);
 #else
-	return smcp_outbound_set_content_formatted_const("v=%ul",v);
+	return smcp_outbound_set_content_formatted_const(self, "v=%ul",v);
 #endif
 }
 
 
 smcp_status_t
-smcp_outbound_quick_response(coap_code_t code, const char* body) {
-	smcp_outbound_begin_response(code);
+smcp_outbound_quick_response(smcp_t self, coap_code_t code, const char* body) {
+	smcp_outbound_begin_response(self, code);
 	if(body)
-		smcp_outbound_append_content(body, SMCP_CSTR_LEN);
-	return smcp_outbound_send();
+		smcp_outbound_append_content(self, body, SMCP_CSTR_LEN);
+	return smcp_outbound_send(self);
 }
 
 smcp_status_t
-smcp_outbound_send() {
+smcp_outbound_send(smcp_t self) {
 	smcp_status_t ret = SMCP_STATUS_FAILURE;
-	smcp_t const self = smcp_get_current_instance();
 
 	if(self->outbound.packet->code) {
-		ret = smcp_auth_outbound_finalize();
+		ret = smcp_auth_outbound_finalize(self);
 		require_noerr(ret,bail);
 	}
 
 #if DEBUG
 	{
-		coap_size_t header_len = (smcp_outbound_get_content_ptr(NULL)-(char*)self->outbound.packet);
+		coap_size_t header_len = (smcp_outbound_get_content_ptr(self, NULL)-(char*)self->outbound.packet);
 
 		// Remove the start-of-payload marker if we have no payload.
-		if(!smcp_get_current_instance()->outbound.content_len)
+		if(!self->outbound.content_len)
 			header_len--;
-		DEBUG_PRINTF("Outbound packet size: %d, %d remaining",header_len+smcp_get_current_instance()->outbound.content_len, smcp_outbound_get_space_remaining());
-		assert(header_len+smcp_get_current_instance()->outbound.content_len<=self->outbound.max_packet_len);
+		DEBUG_PRINTF("Outbound packet size: %d, %d remaining",header_len+self->outbound.content_len, smcp_outbound_get_space_remaining(self));
+		assert(header_len+self->outbound.content_len<=self->outbound.max_packet_len);
 
-		assert(coap_verify_packet((char*)self->outbound.packet,header_len+smcp_get_current_instance()->outbound.content_len));
+		assert(coap_verify_packet((char*)self->outbound.packet,header_len+self->outbound.content_len));
 	}
 #endif // DEBUG
 
@@ -742,9 +717,9 @@ smcp_outbound_send() {
 #if defined(SMCP_DEBUG_OUTBOUND_DROP_PERCENT)
 	if(SMCP_DEBUG_OUTBOUND_DROP_PERCENT*SMCP_RANDOM_MAX>SMCP_FUNC_RANDOM_UINT32()) {
 		DEBUG_PRINTF("Dropping outbound packet for debugging!");
-		if(smcp_get_current_instance()->is_responding)
-			smcp_get_current_instance()->did_respond = true;
-		smcp_get_current_instance()->is_responding = false;
+		if(self->is_responding)
+			self->did_respond = true;
+		self->is_responding = false;
 
 		ret = SMCP_STATUS_OK;
 		goto bail;
@@ -752,19 +727,19 @@ smcp_outbound_send() {
 #endif
 
 #if SMCP_DTLS
-	if(smcp_auth_outbound_is_using_dtls()) {
-		extern smcp_status_t smcp_outbound_send_secure_hook();
-		require((ret = smcp_outbound_send_secure_hook()) == 0, bail);
+	if(smcp_auth_outbound_is_using_dtls(self)) {
+		extern smcp_status_t smcp_outbound_send_secure_hook(smcp_t self);
+		require((ret = smcp_outbound_send_secure_hook(self)) == 0, bail);
 	} else
 #endif
 	{
-		extern smcp_status_t smcp_outbound_send_hook();
-		require((ret = smcp_outbound_send_hook()) == 0, bail);
+		extern smcp_status_t smcp_outbound_send_hook(smcp_t self);
+		require((ret = smcp_outbound_send_hook(self)) == 0, bail);
 	}
 
-	if(smcp_get_current_instance()->is_responding)
-		smcp_get_current_instance()->did_respond = true;
-	smcp_get_current_instance()->is_responding = false;
+	if(self->is_responding)
+		self->did_respond = true;
+	self->is_responding = false;
 
 	ret = SMCP_STATUS_OK;
 bail:

--- a/src/smcp/smcp-plat-bsd-internal.h
+++ b/src/smcp/smcp-plat-bsd-internal.h
@@ -83,6 +83,6 @@
 #error Unsupported value for SMCP_BSD_SOCKETS_NET_FAMILY
 #endif // SMCP_BSD_SOCKETS_NET_FAMILY
 
-extern smcp_status_t smcp_internal_lookup_hostname(const char* hostname, smcp_sockaddr_t* sockaddr);
+extern smcp_status_t smcp_internal_lookup_hostname(smcp_t self, const char* hostname, smcp_sockaddr_t* sockaddr);
 
 #endif

--- a/src/smcp/smcp-timer.c
+++ b/src/smcp/smcp-timer.c
@@ -137,25 +137,24 @@ smcp_timer_compare_func(
 
 smcp_timer_t
 smcp_timer_init(
-	smcp_timer_t			self,
+	smcp_timer_t			timer,
 	smcp_timer_callback_t	callback,
 	smcp_timer_callback_t	cancel,
 	void*					context
 ) {
-	if(self) {
-		memset(self, 0, sizeof(*self));
-		self->context = context;
-		self->callback = callback;
-		self->cancel = cancel;
+	if(timer) {
+		memset(timer, 0, sizeof(*timer));
+		timer->context = context;
+		timer->callback = callback;
+		timer->cancel = cancel;
 	}
-	return self;
+	return timer;
 }
 
 bool
 smcp_timer_is_scheduled(
 	smcp_t self, smcp_timer_t timer
 ) {
-	SMCP_EMBEDDED_SELF_HOOK;
 	return timer->ll.next || timer->ll.prev || (self->timers == timer);
 }
 
@@ -166,7 +165,6 @@ smcp_schedule_timer(
 	cms_t			cms
 ) {
 	smcp_status_t ret = SMCP_STATUS_FAILURE;
-	SMCP_EMBEDDED_SELF_HOOK;
 
 	assert(self!=NULL);
 	assert(timer!=NULL);
@@ -211,7 +209,6 @@ smcp_invalidate_timer(
 	smcp_t	self,
 	smcp_timer_t	timer
 ) {
-	SMCP_EMBEDDED_SELF_HOOK;
 #if SMCP_DEBUG_TIMERS
 	size_t previousTimerCount = ll_count(self->timers);
 	// Sanity check. If we don't have at least one timer
@@ -255,7 +252,6 @@ smcp_dump_all_timers(smcp_t self) {
 cms_t
 smcp_get_timeout(smcp_t self) {
 	cms_t ret = SMCP_MAX_TIMEOUT;
-	SMCP_EMBEDDED_SELF_HOOK;
 
 	if(self->timers)
 		ret = MIN(ret, convert_timeval_to_cms(&self->timers->fire_date));
@@ -273,7 +269,6 @@ smcp_get_timeout(smcp_t self) {
 
 void
 smcp_handle_timers(smcp_t self) {
-	SMCP_EMBEDDED_SELF_HOOK;
 	if(	self->timers
 		&& (convert_timeval_to_cms(&self->timers->fire_date) <= 0)
 	) {

--- a/src/smcp/smcp-timer.h
+++ b/src/smcp/smcp-timer.h
@@ -34,18 +34,6 @@
 #include "ll.h"
 #include "btree.h"
 
-#if SMCP_EMBEDDED
-// On embedded systems, we know we will always only have
-// a single smcp instance, so we can save a considerable
-// amount of stack spaces by simply removing the first argument
-// from many functions. In order to make things as maintainable
-// as possible, these macros do all of the work for us.
-#define smcp_schedule_timer(self,...)		smcp_schedule_timer(__VA_ARGS__)
-#define smcp_invalidate_timer(self,...)		smcp_invalidate_timer(__VA_ARGS__)
-#define smcp_handle_timers(self,...)		smcp_handle_timers(__VA_ARGS__)
-#define smcp_timer_is_scheduled(self,...)		smcp_timer_is_scheduled(__VA_ARGS__)
-#endif
-
 #ifndef MSEC_PER_SEC
 #define MSEC_PER_SEC    (1000)
 #endif

--- a/src/smcp/smcp-transaction.h
+++ b/src/smcp/smcp-transaction.h
@@ -38,20 +38,6 @@
 #include "ll.h"
 #endif
 
-#if SMCP_EMBEDDED
-// On embedded systems, we know we will always only have
-// a single smcp instance, so we can save a considerable
-// amount of stack spaces by simply removing the first argument
-// from many functions. In order to make things as maintainable
-// as possible, these macros do all of the work for us.
-#define smcp_transaction_find_via_msg_id(self,...)		smcp_transaction_find_via_msg_id(__VA_ARGS__)
-#define smcp_transaction_find_via_token(self,...)		smcp_transaction_find_via_token(__VA_ARGS__)
-#define smcp_transaction_begin(self,...)		smcp_transaction_begin(__VA_ARGS__)
-#define smcp_transaction_end(self,...)		smcp_transaction_end(__VA_ARGS__)
-#define smcp_transaction_new_msg_id(self,...)		smcp_transaction_new_msg_id(__VA_ARGS__)
-#define smcp_transaction_tickle(self,...)		smcp_transaction_tickle(__VA_ARGS__)
-#endif
-
 #define SMCP_TRANSACTION_MAX_ATTEMPTS	15
 
 __BEGIN_DECLS
@@ -66,6 +52,7 @@ __BEGIN_DECLS
 /*! Returning pretty much anything here except SMCP_STATUS_OK will
 **	cause the handler to invalidate. */
 typedef smcp_status_t (*smcp_response_handler_func)(
+	smcp_t self,
 	int statuscode,
 	void* context
 );

--- a/src/smcp/smcp-variable_node.h
+++ b/src/smcp/smcp-variable_node.h
@@ -69,6 +69,7 @@ struct smcp_variable_node_s {
 };
 
 extern smcp_status_t smcp_variable_node_request_handler(
+	smcp_t self,
 	smcp_variable_node_t		node
 );
 


### PR DESCRIPTION
I noticed that, when using one smcp_t instance per thread, the library would crash when observing two resources at the same time using two threads.

Using smcp_get_current_instance() within the whole library is broken because it is sometimes returning NULL... I got rid of smcp_set_current_instance() and smcp_get_current_instance(), and modified a lot of prototypes, passing smcp_t instances all around. Crashes are gone!

However:
- Only the library has been modified. As a result, smcpd, smcpctl and other things are not compiling.
- Stack optimizations are now disabled. I propose to declare something like "extern const smcp_t self;" at the top of each file when SMCP_EMBEDDED is defined. A macro adding "const smcp_t self" as a first argument of each function needs to be defined too.

I don't have so much time to deal with that, so I'm just leaving this here so you can cherry-pick my work and build upon it ;)
