### PR TITLE
Little change to ll.h to remove warning

### DIFF
--- a/src/smcp/ll.h
+++ b/src/smcp/ll.h
@@ -142,7 +142,7 @@ ll_insert(
 
 	item_->next = location_;
 	item_->prev = location_->prev;
-	location_->prev = item;
+	location_->prev = item_;
 	if(item_->prev)
 		item_->prev->next = item_;
 


### PR DESCRIPTION
I was using smcp from c++ and the compiler keep warning about a implicit conversion from void * in ll.h

So i changed that line to fix it.