### PR TITLE
Transaction max resends control

### DIFF
--- a/src/examples/example-multicast-request.c
+++ b/src/examples/example-multicast-request.c
@@ -134,6 +134,9 @@ main(int argc, char ** argv)
 		exit(EXIT_FAILURE);
 	}
 
+	//Send no more than one message (or set of bursts) after receives a response
+	transaction->max_resends = 1;
+
 	ctx.transaction = transaction;
 
 	smcp_transaction_begin(instance, transaction, DEFAULT_TIMEOUT);

--- a/src/examples/example-multicast-request.c
+++ b/src/examples/example-multicast-request.c
@@ -134,9 +134,6 @@ main(int argc, char ** argv)
 		exit(EXIT_FAILURE);
 	}
 
-	//Send no more than one message (or set of bursts) after receives a response
-	transaction->max_resends = 1;
-
 	ctx.transaction = transaction;
 
 	smcp_transaction_begin(instance, transaction, DEFAULT_TIMEOUT);

--- a/src/smcp/smcp-transaction.c
+++ b/src/smcp/smcp-transaction.c
@@ -264,6 +264,11 @@ smcp_status_t smcp_internal_resend(smcp_t self, smcp_transaction_t handler, smcp
 		*cms = MIN(*cms, calc_retransmit_timeout(handler->attemptCount, should_burst));
 		handler->attemptCount++;
 	}
+	else if(status == SMCP_STATUS_STOP_RESENDING){
+		//Little hack to stop sending packets (without invalidate the transaction)
+		handler->attemptCount = SMCP_TRANSACTION_MAX_ATTEMPTS;
+		status = SMCP_STATUS_OK;
+	}
 	else if (status == SMCP_STATUS_WAIT_FOR_DNS || status == SMCP_STATUS_WAIT_FOR_SESSION) {
 		// TODO: Figure out a way to avoid polling?
 		*cms = 100;

--- a/src/smcp/smcp-transaction.c
+++ b/src/smcp/smcp-transaction.c
@@ -219,6 +219,81 @@ bail:
 	return;
 }
 
+static
+bool smcp_internal_should_burst(smcp_transaction_t handler){
+	if (handler->flags & SMCP_TRANSACTION_BURST) {
+		if (SMCP_IS_ADDR_MULTICAST(&handler->sockaddr_remote.smcp_addr)) {
+			return SMCP_TRANSACTION_BURST_MULTICAST == (handler->flags & SMCP_TRANSACTION_BURST_MULTICAST);
+		} else {
+			return SMCP_TRANSACTION_BURST_UNICAST == (handler->flags & SMCP_TRANSACTION_BURST_UNICAST);
+		}
+	}
+	return false;
+}
+
+// Checks if not reached the max number of resends
+static bool smcp_internal_can_resend(smcp_transaction_t handler, bool should_burst){
+	int resends = handler->resends_count;
+	if(should_burst){
+		resends /= SMCP_TRANSACTION_BURST_COUNT;
+	}
+
+	return !handler->received_response
+		|| handler->max_resends == SMCP_TRANSACTION_RESENDS_UNLIMITED
+		|| resends < handler->max_resends
+
+		//Send full burst
+		|| (should_burst
+				&& resends == handler->max_resends
+				&& (handler->attemptCount % SMCP_TRANSACTION_BURST_COUNT != 0) //middle of burst
+				);
+}
+
+static
+smcp_status_t smcp_internal_resend(smcp_t self, smcp_transaction_t handler, smcp_cms_t * cms, void* context)
+{
+	bool should_burst = smcp_internal_should_burst(handler);
+
+	if(!smcp_internal_can_resend(handler, should_burst)){
+		return SMCP_STATUS_OK;
+	}
+
+	self->outbound.next_tid = handler->msg_id;
+	self->is_processing_message = false;
+	self->is_responding = false;
+	self->did_respond = false;
+
+	smcp_status_t status = handler->resendCallback(context);
+
+	if (status == SMCP_STATUS_OK) {
+		int max_attempts = SMCP_TRANSACTION_MAX_ATTEMPTS;
+
+		if (should_burst) {
+			max_attempts *= SMCP_TRANSACTION_BURST_COUNT;
+		}
+
+		if (max_attempts > handler->attemptCount) {
+			*cms = MIN(*cms, calc_retransmit_timeout(handler->attemptCount, should_burst));
+			handler->attemptCount++;
+		}
+
+		if(handler->received_response){
+			handler->resends_count++;
+		}
+	} else if (status == SMCP_STATUS_WAIT_FOR_DNS) {
+		// TODO: Figure out a way to avoid polling?
+		*cms = 100;
+		status = SMCP_STATUS_OK;
+
+	} else if (status == SMCP_STATUS_WAIT_FOR_SESSION) {
+		// TODO: Figure out a way to avoid polling?
+		*cms = 100;
+		status = SMCP_STATUS_OK;
+	}
+
+	return status;
+}
+
 static void
 smcp_internal_transaction_timeout_(
 	smcp_t			self,
@@ -251,45 +326,7 @@ smcp_internal_transaction_timeout_(
 		}
 
 		if (status == SMCP_STATUS_TIMEOUT && handler->resendCallback) {
-			// Resend.
-			self->outbound.next_tid = handler->msg_id;
-			self->is_processing_message = false;
-			self->is_responding = false;
-			self->did_respond = false;
-
-			status = handler->resendCallback(context);
-
-			if (status == SMCP_STATUS_OK) {
-				int max_attempts = SMCP_TRANSACTION_MAX_ATTEMPTS;
-				bool should_burst = false;
-
-				if (handler->flags & SMCP_TRANSACTION_BURST) {
-					if (SMCP_IS_ADDR_MULTICAST(&handler->sockaddr_remote.smcp_addr)) {
-						should_burst = SMCP_TRANSACTION_BURST_MULTICAST == (handler->flags & SMCP_TRANSACTION_BURST_MULTICAST);
-					} else {
-						should_burst = SMCP_TRANSACTION_BURST_UNICAST == (handler->flags & SMCP_TRANSACTION_BURST_UNICAST);
-					}
-				}
-
-				if (should_burst) {
-					max_attempts *= SMCP_TRANSACTION_BURST_COUNT;
-				}
-
-				if (max_attempts > handler->attemptCount) {
-					cms = MIN(cms, calc_retransmit_timeout(handler->attemptCount, should_burst));
-					handler->attemptCount++;
-				}
-
-			} else if (status == SMCP_STATUS_WAIT_FOR_DNS) {
-				// TODO: Figure out a way to avoid polling?
-				cms = 100;
-				status = SMCP_STATUS_OK;
-
-			} else if (status == SMCP_STATUS_WAIT_FOR_SESSION) {
-				// TODO: Figure out a way to avoid polling?
-				cms = 100;
-				status = SMCP_STATUS_OK;
-			}
+			status = smcp_internal_resend(self, handler, &cms, context);
 		}
 
 		// Make the attempt count read at least one
@@ -418,7 +455,7 @@ smcp_transaction_init(
 	handler->callback = callback;
 	handler->context = context;
 	handler->flags = (uint8_t)flags;
-
+	handler->max_resends = SMCP_TRANSACTION_RESENDS_UNLIMITED;
 bail:
 	return handler;
 }
@@ -766,6 +803,7 @@ smcp_handle_response() {
 
 		DEBUG_PRINTF("Inbound: Transaction handling response.");
 
+		handler->received_response = true;
 		smcp_inbound_reset_next_option();
 
 #if SMCP_CONF_TRANS_ENABLE_OBSERVING

--- a/src/smcp/smcp-transaction.h
+++ b/src/smcp/smcp-transaction.h
@@ -54,10 +54,6 @@
 
 #define SMCP_TRANSACTION_MAX_ATTEMPTS	15
 
-#define _SMCP_RESENDS_BITS 6
-#define SMCP_TRANSACTION_RESENDS_UNLIMITED	(1 << _SMCP_RESENDS_BITS) - 1
-#define SMCP_TRANSACTION_RESENDS_NONE		0
-
 __BEGIN_DECLS
 /*!	@addtogroup smcp
 **	@{
@@ -110,34 +106,12 @@ struct smcp_transaction_s {
 	coap_code_t					sent_code;
 
 	uint8_t						flags;
-	uint8_t						attemptCount:4,
+	uint8_t						attemptCount:4, maxAttempts:4,
 								waiting_for_async_response:1,
 								should_dealloc:1,
 								active:1,
 								needs_to_close_observe:1,
 								multicast:1;
-
-	bool						received_response : 1;
-
-	//! Defines how many times a (multicast) request will be sent after the transaction receives a response.
-	/*! That is, if max_resends is 0 then the transaction will send requests only
-	 * until receives a response. But if set to 1 it will send more one request,
-	 * and so on.
-	 *
-	 * When the max number of resends is reached, the transaction will not resend
-	 * more requests but will keep waiting for responses until be finished.
-	 *
-	 * If max_resends is \rel SMCP_TRANSACTION_RESENDS_UNLIMITED then the transaction
-	 * will keep resending requests until be finished (or reach the max number of
-	 * attempts).
-	 *
-	 * When #SMCP_TRANSACTION_BURST_MULTICAST flag is set, each set of 'burst'
-	 * messages will be treated as only one request.
-	 */
-	uint8_t						max_resends: _SMCP_RESENDS_BITS;
-
-	//! Counts the number of times a transaction is sent after receive response
-	uint8_t						resends_count:_SMCP_RESENDS_BITS;
 };
 
 typedef struct smcp_transaction_s* smcp_transaction_t;

--- a/src/smcp/smcp-transaction.h
+++ b/src/smcp/smcp-transaction.h
@@ -54,6 +54,10 @@
 
 #define SMCP_TRANSACTION_MAX_ATTEMPTS	15
 
+#define _SMCP_RESENDS_BITS 6
+#define SMCP_TRANSACTION_RESENDS_UNLIMITED	(1 << _SMCP_RESENDS_BITS) - 1
+#define SMCP_TRANSACTION_RESENDS_NONE		0
+
 __BEGIN_DECLS
 /*!	@addtogroup smcp
 **	@{
@@ -112,6 +116,28 @@ struct smcp_transaction_s {
 								active:1,
 								needs_to_close_observe:1,
 								multicast:1;
+
+	bool						received_response : 1;
+
+	//! Defines how many times a (multicast) request will be sent after the transaction receives a response.
+	/*! That is, if max_resends is 0 then the transaction will send requests only
+	 * until receives a response. But if set to 1 it will send more one request,
+	 * and so on.
+	 *
+	 * When the max number of resends is reached, the transaction will not resend
+	 * more requests but will keep waiting for responses until be finished.
+	 *
+	 * If max_resends is \rel SMCP_TRANSACTION_RESENDS_UNLIMITED then the transaction
+	 * will keep resending requests until be finished (or reach the max number of
+	 * attempts).
+	 *
+	 * When #SMCP_TRANSACTION_BURST_MULTICAST flag is set, each set of 'burst'
+	 * messages will be treated as only one request.
+	 */
+	uint8_t						max_resends: _SMCP_RESENDS_BITS;
+
+	//! Counts the number of times a transaction is sent after receive response
+	uint8_t						resends_count:_SMCP_RESENDS_BITS;
 };
 
 typedef struct smcp_transaction_s* smcp_transaction_t;

--- a/src/smcp/smcp.h
+++ b/src/smcp/smcp.h
@@ -124,6 +124,8 @@ enum {
 	SMCP_STATUS_SESSION_CLOSED      = -30,
 	SMCP_STATUS_OUT_OF_SESSIONS     = -31,
 	SMCP_STATUS_UNSUPPORTED_MEDIA_TYPE = -32,
+	//! When returned from a resend callback (in a transaction), stop sending packets without invalidate the transaction
+	SMCP_STATUS_STOP_RESENDING		= -33
 };
 
 typedef int smcp_status_t;


### PR DESCRIPTION
This commit adds some fields to a transaction that enables control
the max number of messages that will be sent after the transaction
receives a response.

This is useful to allow multicast transactions (that keep sending
requests after receives a response) to stop (or limit) resending,
but keep waiting for other responses.